### PR TITLE
Add an expo module

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,6 +21,11 @@ jobs:
         . environment
         npm ci
 
+    - name: prebuild
+      run: |
+        . environment
+        expo prebuild
+
     - name: npm run ci
       run: |
         . environment

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/setup-node@v4.0.1
       with:
         node-version-file: '.node-version'
+        cache: 'npm'
 
     - uses: actions/setup-java@v4.7.0
       with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,7 @@ jobs:
         distribution: temurin
         cache: 'gradle'
 
-    - name: Android SDK
-      uses: amyu/setup-android@v4
+    - uses: amyu/setup-android@v4
 
     - name: npm install
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,10 +16,23 @@ jobs:
       with:
         node-version-file: '.node-version'
 
+    - uses: actions/setup-java@v4.7.0
+      with:
+        java-version: 21
+        distribution: temurin
+
+    - name: Android SDK
+      uses: amyu/setup-android@v4
+
     - name: npm install
       run: |
         . environment
         npm ci
+
+    - name: prebuild
+      run: |
+        . environment
+        expo prebuild
 
     - name: npm run ci
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,11 +21,6 @@ jobs:
         . environment
         npm ci
 
-    - name: prebuild
-      run: |
-        . environment
-        expo prebuild
-
     - name: npm run ci
       run: |
         . environment

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,8 +35,22 @@ jobs:
         . environment
         expo prebuild
 
-    - name: npm run ci
+    - name: npm run lint
       run: |
         . environment
-        npm run ci
+        npm run lint
 
+    - name: tsc
+      run: |
+        . environment
+        tsc
+
+    - name: npm test
+      run: |
+        . environment
+        npm test
+
+    - name: npm run android-test
+      run: |
+        . environment
+        npm run android-test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         java-version: 21
         distribution: temurin
+        cache: 'gradle'
 
     - name: Android SDK
       uses: amyu/setup-android@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ node_modules/
 .expo/
 dist/
 web-build/
+/android
+/ios
 
 # Native
 *.orig.*

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [react native](https://reactnative.dev/)/[Expo](https://expo.dev/) app for testing out new technologies. It shows data from the [spring-experiments](https://github.com/jg210/spring-experiments) API.
 
+Only tested and fully implemented on android.
+
 ## Development Build Instructions
 
 Install nodenv and node-build (or use any other way to put correct version of node on PATH):

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Install nodenv and node-build (or use any other way to put correct version of no
 * https://github.com/nodenv/nodenv#installation
 * https://github.com/nodenv/node-build#installation
 
-To run the app using USB cable on android:
+To run the app on android:
 
 ```
 . environment
 npm i
-npm run android -- --localhost
+npm prebuild
+npm run android
 ```

--- a/TODO
+++ b/TODO
@@ -15,3 +15,5 @@
 * Try out https://docs.expo.dev/guides/react-compiler/
 
 * Run expo-doctor on CI?
+
+* iOS implementation for fingerprintAuthorities.

--- a/TODO
+++ b/TODO
@@ -1,14 +1,6 @@
-* Run native android tests on github actions.
-  - install android SDK etc.
-  - expo prebuild
-  - ./android/gradlew -p android test
-  - easier to use eas?
+* Configure eas.
 
 * More react native testing library tests.
-
-* How can app and module be imported into android studio?
-
-* Configure eas.
 
 * Nicer refresh UI?
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,3 @@
-* Proper fingerprint implementation.
-
 * Test for native module.
 
 * More react native testing library tests.
@@ -7,6 +5,8 @@
 * How can app and module be imported into android studio?
 
 * Configure eas.
+
+* Nicer refresh UI?
 
 * Expo prevents use of eslint 9: https://github.com/expo/expo/issues/28144. eslint 8 is no longer maintained.
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,13 @@
+* Proper fingerprint implementation.
+
+* Test for native module.
+
+* More react native testing library tests.
+
+* How can app and module be imported into android studio?
+
+* Configure eas.
+
 * Expo prevents use of eslint 9: https://github.com/expo/expo/issues/28144. eslint 8 is no longer maintained.
 
 * eslint react-hooks/exhaustive-deps disabled.

--- a/TODO
+++ b/TODO
@@ -1,4 +1,8 @@
-* Test for native module.
+* Run native android tests on github actions.
+  - install android SDK etc.
+  - expo prebuild
+  - ./android/gradlew -p android test
+  - easier to use eas?
 
 * More react native testing library tests.
 

--- a/app.json
+++ b/app.json
@@ -16,13 +16,15 @@
     ],
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "uk.me.jeremygreen.expoexperiments"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "uk.me.jeremygreen.expoexperiments"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/environment
+++ b/environment
@@ -5,7 +5,7 @@
 SOURCE_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # java
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 export PATH="${JAVA_HOME}/bin:${PATH}"
 
 # node
@@ -18,5 +18,7 @@ fi
 PATH="${SOURCE_DIR}/node_modules/.bin:${PATH}"
 
 # Android SDK.
-export ANDROID_HOME=~/Android/Sdk
-export PATH="${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${PATH}"
+if [ ! -v GITHUB_ACTIONS ] ;
+    export ANDROID_HOME=~/Android/Sdk
+    export PATH="${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${PATH}"
+fi

--- a/environment
+++ b/environment
@@ -18,7 +18,7 @@ fi
 PATH="${SOURCE_DIR}/node_modules/.bin:${PATH}"
 
 # Android SDK.
-if [ ! -v GITHUB_ACTIONS ] ;
+if [ ! -v GITHUB_ACTIONS ] ; then
     export ANDROID_HOME=~/Android/Sdk
     export PATH="${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${PATH}"
 fi

--- a/environment
+++ b/environment
@@ -5,8 +5,10 @@
 SOURCE_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # java
-export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
-export PATH="${JAVA_HOME}/bin:${PATH}"
+if [ ! -v GITHUB_ACTIONS ] ; then
+    export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+    export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
 
 # node
 if [ -d "${HOME}/.nodenv/bin" ] ; then

--- a/modules/expo-experiments/android/.gitignore
+++ b/modules/expo-experiments/android/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+build
+local.properties

--- a/modules/expo-experiments/android/build.gradle
+++ b/modules/expo-experiments/android/build.gradle
@@ -1,0 +1,43 @@
+apply plugin: 'com.android.library'
+
+group = 'uk.me.jeremygreen.expoexperiments'
+version = '0.6.3'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
+// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
+// Most of the time, you may like to manage the Android SDK versions yourself.
+def useManagedAndroidSdkVersions = false
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    // Simple helper that allows the root project to override versions declared by this library.
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+  }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 21)
+      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+    }
+  }
+}
+
+android {
+  namespace "uk.me.jeremygreen.expoexperiments"
+  defaultConfig {
+    versionCode 1
+    versionName "0.6.3"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/modules/expo-experiments/android/build.gradle
+++ b/modules/expo-experiments/android/build.gradle
@@ -41,3 +41,6 @@ android {
     abortOnError false
   }
 }
+dependencies {
+  api 'junit:junit:4.13.2'
+}

--- a/modules/expo-experiments/android/src/main/AndroidManifest.xml
+++ b/modules/expo-experiments/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/expo-experiments/android/src/main/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModule.kt
+++ b/modules/expo-experiments/android/src/main/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModule.kt
@@ -13,8 +13,9 @@ class ExpoExperimentsModule : Module() {
     // Ensures e.g. fingerprint of ["a", "bc"] is different to fingerprint of ["ab", "c"].
     private val DIGEST_SEPARATOR = byteArrayOf(0)
 
+    // This wrapper only exists to add the @OptIn.
     @OptIn(ExperimentalStdlibApi::class)
-    fun hexString(byteArray: ByteArray) : String = byteArray.toHexString()
+    fun ByteArray.hexString() : String = this.toHexString()
 
     fun fingerprintAuthorities(authorities: List<String>): String {
       val digest = MessageDigest.getInstance("SHA-256")
@@ -22,7 +23,7 @@ class ExpoExperimentsModule : Module() {
         digest.update(authority.encodeToByteArray())
         digest.update(DIGEST_SEPARATOR)
       }
-      val fingerprint = hexString(digest.digest())
+      val fingerprint = digest.digest().hexString()
       return fingerprint
     }
 

--- a/modules/expo-experiments/android/src/main/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModule.kt
+++ b/modules/expo-experiments/android/src/main/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModule.kt
@@ -1,0 +1,20 @@
+package uk.me.jeremygreen.expoexperiments
+
+import expo.modules.kotlin.Promise
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.net.URL
+
+class ExpoExperimentsModule : Module() {
+
+  // See https://docs.expo.dev/modules/module-api for more details about available components.
+  override fun definition() = ModuleDefinition {
+    Name("ExpoExperiments")
+
+    AsyncFunction("fingerprintAuthorities") { authorities: List<String>, promise: Promise ->
+      promise.resolve("1234")
+    }
+
+  }
+}

--- a/modules/expo-experiments/android/src/main/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModule.kt
+++ b/modules/expo-experiments/android/src/main/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModule.kt
@@ -4,16 +4,28 @@ import expo.modules.kotlin.Promise
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import java.net.URL
+import java.security.MessageDigest
 
 class ExpoExperimentsModule : Module() {
+
+  companion object {
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun hexString(byteArray: ByteArray) : String = byteArray.toHexString()
+  }
 
   // See https://docs.expo.dev/modules/module-api for more details about available components.
   override fun definition() = ModuleDefinition {
     Name("ExpoExperiments")
 
     AsyncFunction("fingerprintAuthorities") { authorities: List<String>, promise: Promise ->
-      promise.resolve("1234")
+      val digest = MessageDigest.getInstance("SHA-256")
+      val separator = byteArrayOf(0)
+      authorities.forEach  { authority ->
+        digest.digest(authority.encodeToByteArray())
+        digest.digest(separator)
+      }
+      val fingerprint = hexString(digest.digest())
+      promise.resolve(fingerprint)
     }
 
   }

--- a/modules/expo-experiments/android/src/test/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModuleTest.kt
+++ b/modules/expo-experiments/android/src/test/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModuleTest.kt
@@ -1,6 +1,7 @@
 import org.junit.Assert
 import org.junit.Test
 import uk.me.jeremygreen.expoexperiments.ExpoExperimentsModule
+import uk.me.jeremygreen.expoexperiments.ExpoExperimentsModule.Companion.hexString
 
 class ExpoExperimentsModuleTest {
 
@@ -8,7 +9,7 @@ class ExpoExperimentsModuleTest {
     fun hexString() {
         Assert.assertEquals(
             "000102ff",
-            ExpoExperimentsModule.hexString(byteArrayOf(0, 1, 2, 255.toByte()))
+            byteArrayOf(0, 1, 2, 255.toByte()).hexString()
         )
     }
 
@@ -16,7 +17,7 @@ class ExpoExperimentsModuleTest {
     fun `hexString empty`() {
         Assert.assertEquals(
             "",
-            ExpoExperimentsModule.hexString(byteArrayOf())
+            byteArrayOf().hexString()
         )
     }
 

--- a/modules/expo-experiments/android/src/test/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModuleTest.kt
+++ b/modules/expo-experiments/android/src/test/java/uk/me/jeremygreen/expoexperiments/ExpoExperimentsModuleTest.kt
@@ -1,0 +1,53 @@
+import org.junit.Assert
+import org.junit.Test
+import uk.me.jeremygreen.expoexperiments.ExpoExperimentsModule
+
+class ExpoExperimentsModuleTest {
+
+    @Test
+    fun hexString() {
+        Assert.assertEquals(
+            "000102ff",
+            ExpoExperimentsModule.hexString(byteArrayOf(0, 1, 2, 255.toByte()))
+        )
+    }
+
+    @Test
+    fun `hexString empty`() {
+        Assert.assertEquals(
+            "",
+            ExpoExperimentsModule.hexString(byteArrayOf())
+        )
+    }
+
+    @Test
+    fun `fingerprintAuthorities empty list`() {
+        Assert.assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            ExpoExperimentsModule.fingerprintAuthorities(listOf()))
+    }
+
+    @Test
+    fun `fingerprintAuthorities one element`() {
+        Assert.assertEquals(
+            "ffe9aaeaa2a2d5048174df0b80599ef0197ec024c4b051bc9860cff58ef7f9f3",
+            ExpoExperimentsModule.fingerprintAuthorities(listOf("a")))
+    }
+
+    @Test
+    fun `fingerprintAuthorities separator`() {
+        Assert.assertNotEquals(
+            ExpoExperimentsModule.fingerprintAuthorities(listOf("a", "bc")),
+            ExpoExperimentsModule.fingerprintAuthorities(listOf("ab", "c"))
+        )
+    }
+
+    @Test
+    fun `fingerprintAuthorities permutation`() {
+        Assert.assertNotEquals(
+            ExpoExperimentsModule.fingerprintAuthorities(listOf("a", "b")),
+            ExpoExperimentsModule.fingerprintAuthorities(listOf("b", "a"))
+        )
+    }
+
+}

--- a/modules/expo-experiments/expo-module.config.json
+++ b/modules/expo-experiments/expo-module.config.json
@@ -1,0 +1,17 @@
+{
+  "platforms": [
+    "apple",
+    "android",
+    "web"
+  ],
+  "apple": {
+    "modules": [
+      "ExpoExperimentsModule"
+    ]
+  },
+  "android": {
+    "modules": [
+      "uk.me.jeremygreen.expoexperiments.ExpoExperimentsModule"
+    ]
+  }
+}

--- a/modules/expo-experiments/index.ts
+++ b/modules/expo-experiments/index.ts
@@ -1,0 +1,2 @@
+export { default } from './src/ExpoExperimentsModule';
+export * from  './src/ExpoExperiments.types';

--- a/modules/expo-experiments/ios/ExpoExperiments.podspec
+++ b/modules/expo-experiments/ios/ExpoExperiments.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'ExpoExperiments'
+  s.version        = '1.0.0'
+  s.summary        = 'A sample project summary'
+  s.description    = 'A sample project description'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/expo-experiments/ios/ExpoExperimentsModule.swift
+++ b/modules/expo-experiments/ios/ExpoExperimentsModule.swift
@@ -1,0 +1,12 @@
+import ExpoModulesCore
+
+public class ExpoExperimentsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoExperiments")
+
+    AsyncFunction("fingerprintAuthorities") { (authorities: String[], promise: Promise) in
+      promise.resolve("1234") // TODO implement fingerprinting
+    }
+
+  }
+}

--- a/modules/expo-experiments/src/ExpoExperiments.types.ts
+++ b/modules/expo-experiments/src/ExpoExperiments.types.ts
@@ -1,0 +1,3 @@
+export type ExpoExperimentsModuleEvents = {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
+
+

--- a/modules/expo-experiments/src/ExpoExperimentsModule.ts
+++ b/modules/expo-experiments/src/ExpoExperimentsModule.ts
@@ -3,7 +3,7 @@ import { NativeModule, requireNativeModule } from 'expo';
 import { ExpoExperimentsModuleEvents } from './ExpoExperiments.types';
 
 declare class ExpoExperimentsModule extends NativeModule<ExpoExperimentsModuleEvents> {
-  setValueAsync(authorities: string[]): Promise<string>;
+  fingerprintAuthorities(authorities: string[]): Promise<string>;
 }
 
 // This call loads the native module object from the JSI.

--- a/modules/expo-experiments/src/ExpoExperimentsModule.ts
+++ b/modules/expo-experiments/src/ExpoExperimentsModule.ts
@@ -1,0 +1,10 @@
+import { NativeModule, requireNativeModule } from 'expo';
+
+import { ExpoExperimentsModuleEvents } from './ExpoExperiments.types';
+
+declare class ExpoExperimentsModule extends NativeModule<ExpoExperimentsModuleEvents> {
+  setValueAsync(authorities: string[]): Promise<string>;
+}
+
+// This call loads the native module object from the JSI.
+export default requireNativeModule<ExpoExperimentsModule>('ExpoExperiments');

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "eslint --max-warnings=0 .",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "lint": "eslint --max-warnings=0 .",
     "test": "jest",
-    "ci": "npm run lint && tsc && npm test && ./android/gradlew -p android test"
+    "ci": "npm run lint && tsc && npm test"
   },
   "dependencies": {
     "@tanstack/react-query": "5.65.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "web": "expo start --web",
     "lint": "eslint --max-warnings=0 .",
     "test": "jest",
-    "ci": "npm run lint && tsc && npm test && ./android/gradlew -p android test"
+    "android-test": "./android/gradlew -p android test",
+    "ci": "npm run lint && tsc && npm test && npm run android-test"
   },
   "dependencies": {
     "@tanstack/react-query": "5.65.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "lint": "eslint --max-warnings=0 .",
     "test": "jest",
-    "ci": "npm run lint && tsc && npm test"
+    "ci": "npm run lint && tsc && npm test && ./android/gradlew -p android test"
   },
   "dependencies": {
     "@tanstack/react-query": "5.65.1",

--- a/src/Authorities.tsx
+++ b/src/Authorities.tsx
@@ -1,9 +1,13 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { FlatList, Text } from "react-native";
 
 import { getAuthorities } from "./FSA";
 import { useRefresh } from "./useRefresh";
+
+import React from 'react';
+
+import ExpoExperimentsModule from "../modules/expo-experiments/src/ExpoExperimentsModule";
 
 const queryKey = ["authorities"];
 
@@ -21,15 +25,28 @@ const AuthoritiesImpl = () => {
     queryKey,
     queryFn: getAuthorities,
   });
+  // The fingerprint will be stale during refreshes, so need to hide it somehow.
+  // The string initial loading state uses same string, although in this case
+  // refreshing is false.
+  const refreshingText = "...";
+  const [fingerprint, setFingerprint] = useState(refreshingText);
   const { refreshing, onRefresh } = useRefresh(refetch);
+  const localAuthorityNames = data.map(localAuthority => localAuthority.name)
+  // TODO with react 19 use(), could use Suspense while wait for Promise to resolve.
+  useEffect(() => {
+    ExpoExperimentsModule.fingerprintAuthorities(localAuthorityNames).then(fingerprint => setFingerprint(fingerprint));
+  }, [localAuthorityNames]);
   return (
-    <FlatList
-      data={data}
-      renderItem={({ item }) => <Item name={item.name} />}
-      keyExtractor={(item) => item.localAuthorityId.toString()}
-      onRefresh={onRefresh}
-      refreshing={refreshing}
-    />
+    <>
+      <Text>{refreshing ? refreshingText : fingerprint}</Text>
+      <FlatList
+        data={data}
+        renderItem={({ item }) => <Item name={item.name} />}
+        keyExtractor={(item) => item.localAuthorityId.toString()}
+        onRefresh={onRefresh}
+        refreshing={refreshing}
+      />
+    </>
   );
 };
 

--- a/src/Authorities.tsx
+++ b/src/Authorities.tsx
@@ -34,7 +34,9 @@ const AuthoritiesImpl = () => {
   const localAuthorityNames = data.map(localAuthority => localAuthority.name)
   // TODO with react 19 use(), could use Suspense while wait for Promise to resolve.
   useEffect(() => {
-    ExpoExperimentsModule.fingerprintAuthorities(localAuthorityNames).then(fingerprint => setFingerprint(fingerprint));
+    ExpoExperimentsModule.fingerprintAuthorities(localAuthorityNames).then(fingerprint => {
+      setFingerprint(fingerprint.substring(0,8));
+    });
   }, [localAuthorityNames]);
   return (
     <>


### PR DESCRIPTION
* Adds an expo native module that calculates SHA-256 sum of the authority names and shows it in the UI.
* Enables running of android tests on github actions.
* Various improvements to github action config.

