### PR TITLE
Avoid Promise race

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,4 +12,9 @@ module.exports = {
       },
     },
   ],
+  rules: {
+    "react-hooks/exhaustive-deps": ["error", {
+      "additionalHooks": "(useLastPromise)"
+    }]
+  }
 };

--- a/TODO
+++ b/TODO
@@ -1,3 +1,8 @@
+* error TS2339: Property 'version' does not exist on type 'typeof process'.
+  - in src/__tests__/nodeVersion.tsx
+  - why didn't CI fail with this?
+    - it runs tsc
+
 * Add a turbomodule too, to compare with the expo native module.
 
 * More react native testing library tests.
@@ -25,3 +30,5 @@
 * iOS implementation for fingerprintAuthorities.
 
 * Contribute something to eas build that lets it parse .node-version so don't need to specify in eas.json?
+
+* Is it possible to test that react-hooks/exhaustive-deps checks useLastPromise?

--- a/TODO
+++ b/TODO
@@ -3,6 +3,22 @@
   - why didn't CI fail with this?
     - it runs tsc
 
+* Add Authorities.test.tsx
+  - expo module mocking not working...
+  - describe("Authorities", () => {
+        it("renders", async () => {
+            // Mock react-query
+            jest.mock("@tanstack/react-query");
+            const data: LocalAuthority[] = [
+                { localAuthorityId: 1, name: "Wessex" }
+            ];
+            const refetch = jest.fn();
+            (useSuspenseQuery as jest.Mock).mockImplementation(() => ({ data, refetch }));
+            // TODO Mock expo module: https://docs.expo.dev/modules/mocking/
+            render(<Authorities/>);
+        });
+    });
+
 * Add a turbomodule too, to compare with the expo native module.
 
 * More react native testing library tests.

--- a/src/Authorities.tsx
+++ b/src/Authorities.tsx
@@ -34,9 +34,13 @@ const AuthoritiesImpl = () => {
   const localAuthorityNames = data.map(localAuthority => localAuthority.name)
   // TODO with react 19 use(), could use Suspense while wait for Promise to resolve.
   useEffect(() => {
+    let ignore = false;
     ExpoExperimentsModule.fingerprintAuthorities(localAuthorityNames).then(fingerprint => {
-      setFingerprint(fingerprint.substring(0,8));
+      if (!ignore) {
+        setFingerprint(fingerprint.substring(0,8));
+      }
     });
+    return () => { ignore = true };
   }, [localAuthorityNames]);
   return (
     <>

--- a/src/Authorities.tsx
+++ b/src/Authorities.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useState } from "react";
 import { FlatList, Text } from "react-native";
 
 import { getAuthorities } from "./FSA";
@@ -8,6 +8,7 @@ import { useRefresh } from "./useRefresh";
 import React from 'react';
 
 import ExpoExperimentsModule from "../modules/expo-experiments/src/ExpoExperimentsModule";
+import { useLastPromise } from "./useLastPromise";
 
 const queryKey = ["authorities"];
 
@@ -33,15 +34,11 @@ const AuthoritiesImpl = () => {
   const { refreshing, onRefresh } = useRefresh(refetch);
   const localAuthorityNames = data.map(localAuthority => localAuthority.name)
   // TODO with react 19 use(), could use Suspense while wait for Promise to resolve.
-  useEffect(() => {
-    let ignore = false;
-    ExpoExperimentsModule.fingerprintAuthorities(localAuthorityNames).then(fingerprint => {
-      if (!ignore) {
-        setFingerprint(fingerprint.substring(0,8));
-      }
-    });
-    return () => { ignore = true };
-  }, [localAuthorityNames]);
+  useLastPromise(
+    () => ExpoExperimentsModule.fingerprintAuthorities(localAuthorityNames),
+    [localAuthorityNames],
+    (fingerprint) => setFingerprint(fingerprint.substring(0, 8))
+  );
   return (
     <>
       <Text>{refreshing ? refreshingText : fingerprint}</Text>

--- a/src/__tests__/useLastPromise.test.tsx
+++ b/src/__tests__/useLastPromise.test.tsx
@@ -33,7 +33,7 @@ describe("useLastPromise", () => {
         commit: CommitFunction<Value>
     };
     const TestHarness = ({ promise, commit }: Props) => {
-        useLastPromise(promise, [promise], commit)
+        useLastPromise(promise, [promise, commit], commit)
         return <div></div>;
     }
     let promise1Resolver: ((value: number) => void) | null = null;

--- a/src/__tests__/useLastPromise.test.tsx
+++ b/src/__tests__/useLastPromise.test.tsx
@@ -36,11 +36,11 @@ describe("useLastPromise", () => {
         useLastPromise(promise, [promise], commit)
         return <div></div>;
     }
-    let promiseSlowResolver: ((value: number) => void) | null = null;
+    let promise1Resolver: ((value: number) => void) | null = null;
     const promise1Value = 234234;
     const promise2Value: Value = Math.random();
     expect(promise1Value).not.toEqual(promise2Value);
-    const promise1: PromiseFunction<Value> = () => new Promise((resolve, _reject) => { promiseSlowResolver = resolve }); // slow
+    const promise1: PromiseFunction<Value> = () => new Promise((resolve, _reject) => { promise1Resolver = resolve }); // slow
     const promise2: PromiseFunction<Value> = async () => promise2Value; // fast
     const commit1 = jest.fn<CommitFunction<Value>>()
     const commit2 = jest.fn<CommitFunction<Value>>()
@@ -50,8 +50,8 @@ describe("useLastPromise", () => {
     rerender(
         <TestHarness promise={promise2} commit={commit2} />
     );
-    await waitFor(() => expect(promiseSlowResolver).toBeDefined());
-    promiseSlowResolver!(promise1Value);
+    await waitFor(() => expect(promise1Resolver).toBeDefined());
+    promise1Resolver!(promise1Value);
     expect(commit1).toHaveBeenCalledTimes(0);
     expect(commit2).toHaveBeenCalledWith(promise2Value);
   });

--- a/src/__tests__/useLastPromise.test.tsx
+++ b/src/__tests__/useLastPromise.test.tsx
@@ -1,0 +1,15 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { useLastPromise } from "../useLastPromise";
+
+describe("useLastPromise", () => {
+  
+  it("passes value from promise to commit", async () => {
+    const value = "testing 123";
+    const promise = async () => value;
+    const commit = jest.fn();
+    const { result } = renderHook(() => useLastPromise(promise, [], commit));
+    expect(result.current).toBe(undefined);
+    await waitFor(() => expect(commit).toHaveBeenCalledWith(value));
+  });
+
+});

--- a/src/__tests__/useLastPromise.test.tsx
+++ b/src/__tests__/useLastPromise.test.tsx
@@ -1,15 +1,29 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
-import { useLastPromise } from "../useLastPromise";
+import { CommitFunction, PromiseFunction, useLastPromise } from "../useLastPromise";
+
+import { expect, jest } from '@jest/globals';
+import React from "react";
 
 describe("useLastPromise", () => {
   
   it("passes value from promise to commit", async () => {
     const value = "testing 123";
-    const promise = async () => value;
-    const commit = jest.fn();
+    const promise: PromiseFunction<typeof value> = async () => value;
+    const commit = jest.fn<CommitFunction<typeof value>>();
     const { result } = renderHook(() => useLastPromise(promise, [], commit));
     expect(result.current).toBe(undefined);
     await waitFor(() => expect(commit).toHaveBeenCalledWith(value));
+  });
+
+  it("passes deps to useEffect", async () => {
+    const [ x, y, z ] = [1, 2, 3];
+    type Value = number;
+    const promise: PromiseFunction<Value> = async () => x + y + z;
+    const commit = jest.fn<CommitFunction<Value>>();
+    const useEffectMock = jest.spyOn(React, "useEffect");
+    const deps = [x, y, z];
+    renderHook(() => useLastPromise(promise, deps, commit));
+    expect(useEffectMock).toHaveBeenCalledWith(expect.any(Function), deps);
   });
 
 });

--- a/src/useLastPromise.tsx
+++ b/src/useLastPromise.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+// Ensures racing promises can't be reordered.
+//
+// Based on pattern from https://react.dev/learn/synchronizing-with-effects#fetching-data
+//
+// react-hooks/exhaustive-deps is configured with additionalHooks to check the deps.
+// It expects first and second args to look like useEffect's args, so promise and deps must be
+// first and second argument.
+//
+// promise - returns Promise that depends on just deps
+// deps - same as for useEffect
+// commit - given the value returned by promise unless there's a newer render in progress. If it depends on any values, they'd need to go in deps too.
+export function useLastPromise<T>(
+  promise: () => Promise<T>,
+  deps: React.DependencyList,
+  commit: (value: T) => void) {
+    useEffect(
+      () => {
+        let ignore = false;
+        promise().then(value => {
+          if (!ignore) {
+            commit(value);
+          }
+        });
+        return () => { ignore = true };
+      },
+      deps // eslint-disable-line react-hooks/exhaustive-deps
+    );
+};
+  

--- a/src/useLastPromise.tsx
+++ b/src/useLastPromise.tsx
@@ -6,7 +6,7 @@ import { useEffect } from "react";
 //
 // react-hooks/exhaustive-deps is configured with additionalHooks to check the deps.
 // It expects first and second args to look like useEffect's args, so promise and deps must be
-// first and second argument.
+// first and second argument. It won't check commit function for missing deps.
 //
 // promise - returns Promise that depends on just deps
 // deps - same as for useEffect

--- a/src/useLastPromise.tsx
+++ b/src/useLastPromise.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from "react";
 
+export type PromiseFunction<T> = () => Promise<T>;
+export type CommitFunction<T> = (value: T) => void;
+
 // Ensures racing promises can't be reordered.
 //
 // Based on pattern from https://react.dev/learn/synchronizing-with-effects#fetching-data
@@ -12,9 +15,9 @@ import { useEffect } from "react";
 // deps - same as for useEffect
 // commit - given the value returned by promise unless there's a newer render in progress. If it depends on any values, they'd need to go in deps too.
 export function useLastPromise<T>(
-  promise: () => Promise<T>,
+  promise: PromiseFunction<T>,
   deps: React.DependencyList,
-  commit: (value: T) => void) {
+  commit: CommitFunction<T>) {
     useEffect(
       () => {
         let ignore = false;


### PR DESCRIPTION
The list of authorities is passed to native code to calculate a fingerprint. Theoretically (e.g. if native code changed to use a thread pool), the promises for this could resolve out of order for different renders.