### PR TITLE
iOS DiagnosticReports backtraces

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -208,3 +208,17 @@ jobs:
             ~/Library/Logs/CoreSimulator/CoreSimulator.log
             ~/Library/Logs/DiagnosticReports/
           if-no-files-found: error
+
+      - name: extract crash backtrace from any DiagnosticReports
+        if: success() || failure()    # run this step even if previous step failed
+        run: |
+            shopt -s nullglob
+            for f in ~/Library/Logs/DiagnosticReports/expoexperiments-*.ips ; do
+              {
+                # TODO add a script that also escapes any ``` in content.
+                printf '```\n'
+                printf '\n%s:\n' "${f}"
+                tail -n +2 "${f}" | jq -r '.lastExceptionBacktrace[].symbol'
+                printf '```\n'
+              } | tee -a "${GITHUB_STEP_SUMMARY}"
+            done

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -204,15 +204,7 @@ jobs:
           path: |
             ~/.maestro/tests/
             ~/Library/Logs/maestro/
-          if-no-files-found: error
-
-      - name: simulator logs
-        uses: actions/upload-artifact@v4
-        if: success() || failure()    # run this step even if previous step failed
-        with:
-          name: simulator logs
-          path: |
             ios_simulator_logs.txt
             ~/Library/Logs/CoreSimulator/CoreSimulator.log
+            ~/Library/Logs/DiagnosticReports/
           if-no-files-found: error
-  


### PR DESCRIPTION
Cherry picks the commits from https://github.com/jg210/expo-experiments/pull/15, so can more easily see if the crashes are getting on that branch are also happening on the master branch.

iOS records crashes in files in a json-like format. This PR:

* Saves the files as artifacts.
* Extracts the backtrace symbols using jq (which is preinstalled on github macos runners).
* Stores backtraces in step summary (and logs).
* Also puts all maestro logs into same github artifact archive, to make it easier to see all the logs in same place.