### PR TITLE
Check git status is empty at end of each Github Actions job.

### DIFF
--- a/.github/actions/git-status/action.yml
+++ b/.github/actions/git-status/action.yml
@@ -1,0 +1,7 @@
+name: "non-empty git status"
+description: "Fails if git status is non-empty."
+runs:
+  using: "composite"
+  steps:
+    - name: "git status"
+    - run: test -z "$(git status --porcelain)"

--- a/.github/actions/git-status/action.yml
+++ b/.github/actions/git-status/action.yml
@@ -4,4 +4,5 @@ runs:
   using: "composite"
   steps:
     - name: "git status"
-    - run: test -z "$(git status --porcelain)"
+      shell: bash
+      run: test -z "$(git status --porcelain)"

--- a/.github/actions/git-status/action.yml
+++ b/.github/actions/git-status/action.yml
@@ -5,4 +5,8 @@ runs:
   steps:
     - name: "git status"
       shell: bash
-      run: test -z "$(git status --porcelain)"
+      run: |
+        if [ -n "$(git status --porcelain)" ] ; then
+          git status
+          exit 1
+        fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -232,7 +232,7 @@ jobs:
           path: |
             ~/.maestro/tests/
             ~/Library/Logs/maestro/
-            ios_simulator_logs.txt
+            ${{ runner.temp }}/ios_simulator_logs.txt
             ~/Library/Logs/CoreSimulator/CoreSimulator.log
             ~/Library/Logs/DiagnosticReports/
           if-no-files-found: error

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -111,6 +111,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: app-release.apk
+          path: ${{ runner.temp }}
 
       - name: enable KVM group perms
         run: |
@@ -212,6 +213,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: expoexperiments.app
+          path: ${{ runner.temp }}
 
       - name: install maestro
         run: scripts/install_maestro

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,9 @@ jobs:
         . environment
         npm test
 
+    # git-status must be last step
+    - uses: ./.github/actions/git-status
+
   android:
     runs-on: ubuntu-24.04
     steps:
@@ -88,6 +91,10 @@ jobs:
         name: app-release.apk
         path: android/app/build/outputs/apk/release/app-release.apk
 
+    # git-status must be last step
+    - uses: ./.github/actions/git-status
+
+
   android-test:
     runs-on: ubuntu-24.04
     needs: android # for the apk
@@ -145,7 +152,10 @@ jobs:
           name: logcat.txt - API ${{ matrix.api-level }}
           path: logcat.txt
           if-no-files-found: error
-  
+
+      # git-status must be last step
+      - uses: ./.github/actions/git-status
+
   ios:
     runs-on: macos-15
 
@@ -187,6 +197,10 @@ jobs:
         path: ios/build/Build/Products/Release-iphonesimulator
         if-no-files-found: error
     
+    # git-status must be last step
+    - uses: ./.github/actions/git-status
+
+
   ios-test:
     runs-on: macos-14
     needs: ios # for the app
@@ -231,3 +245,6 @@ jobs:
                 printf '```\n'
               } | tee -a "${GITHUB_STEP_SUMMARY}"
             done
+
+      # git-status must be last step
+      - uses: ./.github/actions/git-status

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -200,7 +200,6 @@ jobs:
     # git-status must be last step
     - uses: ./.github/actions/git-status
 
-
   ios-test:
     runs-on: macos-14
     needs: ios # for the app

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -197,9 +197,6 @@ jobs:
         name: expoexperiments.app
         path: ios/build/Build/Products/Release-iphonesimulator
         if-no-files-found: error
-    
-    - name: ls -lR
-      run : ls -lR .
 
     # git-status must be last step
     - uses: ./.github/actions/git-status

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -151,7 +151,7 @@ jobs:
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: logcat.txt - API ${{ matrix.api-level }}
-          path: logcat.txt
+          path: ${{ runner.temp }}/logcat.txt
           if-no-files-found: error
 
       # git-status must be last step

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -94,7 +94,6 @@ jobs:
     # git-status must be last step
     - uses: ./.github/actions/git-status
 
-
   android-test:
     runs-on: ubuntu-24.04
     needs: android # for the apk

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -198,6 +198,9 @@ jobs:
         path: ios/build/Build/Products/Release-iphonesimulator
         if-no-files-found: error
     
+    - name: ls -lR
+      run : ls -lR .
+
     # git-status must be last step
     - uses: ./.github/actions/git-status
 

--- a/e2e/maestro/run_maestro_ci
+++ b/e2e/maestro/run_maestro_ci
@@ -26,7 +26,7 @@ ios() {
     xcrun simctl boot "${simulator}"
     log "installing app from: ${app}"
     xcrun simctl install booted "${app}"
-    exec with_ios_logs ios_simulator_logs.txt scripts/run_maestro
+    exec with_ios_logs "${RUNNER_TEMP}/ios_simulator_logs.txt" scripts/run_maestro
 }
 
 case "${platform}" in

--- a/e2e/maestro/run_maestro_ci
+++ b/e2e/maestro/run_maestro_ci
@@ -12,7 +12,7 @@ platform=$1
 shift
 
 android() {
-    apk=app-release.apk
+    apk="${RUNNER_TEMP}/app-release.apk"
     log "installing: ${apk}"
     adb install "${apk}"
     log "running maestro."
@@ -20,7 +20,7 @@ android() {
 }
 
 ios() {
-    app=./expoexperiments.app
+    app="${RUNNER_TEMP}/expoexperiments.app"
     simulator="iPhone 16"
     log "starting simulator: ${simulator}"
     xcrun simctl boot "${simulator}"

--- a/e2e/maestro/run_maestro_ci
+++ b/e2e/maestro/run_maestro_ci
@@ -16,7 +16,7 @@ android() {
     log "installing: ${apk}"
     adb install "${apk}"
     log "running maestro."
-    exec with_emulator_status with_logcat logcat.txt scripts/run_maestro
+    exec with_emulator_status with_logcat "${RUNNER_TEMP}/logcat.txt" scripts/run_maestro
 }
 
 ios() {


### PR DESCRIPTION
This means that jobs fail if e.g. forget to:

* Update package-lock.json
* Update some other lock file.
* Don't add a build output directory to .gitignore
* ...

Composite github actions are documented here:

https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action

Had to fix various things that were putting files in git repo, using RUNNER_TEMP directory instead.